### PR TITLE
add --exclude flag for excluding directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Linux distributions may not be recognized.
 # Usage
 
 ``` console
-$ ./log4j-vuln-scanner /path/to/app1 /path/to/app2 …
+$ ./log4j-vuln-scanner [--exclude /path/to/exclude …] /path/to/app1 /path/to/app2 …
 ```
 
 If class files indicating one of the vulnerabilities are found,


### PR DESCRIPTION
This PR adds support for --exclude flags. 

With this flag it is possible to exclude directories from scanning.

Example:

```./local-log4j-vuln-scanner --exclude /proc --exclude /dev --exclude /mnt --exclude /sys /```

This is especially useful to exclude distributed file systems (nfs/cifs/gpfs/...).


