### PR TITLE
GOFLAGS="-trimpath" for reproducible builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Build
       run: |
-        export GOFLAGS="-trimpath"
+        export GOFLAGS="-buildmode=pie -trimpath"
         go version
         go build .
         GOOS=windows go build .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,7 @@ jobs:
 
     - name: Build
       run: |
+        export GOFLAGS="-trimpath"
         go version
         go build .
         GOOS=windows go build .


### PR DESCRIPTION
Set `GOFLAGS="-buildmode=pie -trimpath"` to enable reproducible builds and position-independent executables

The following two builds yield the same sha256sum:

- https://github.com/simon04/local-log4j-vuln-scanner/actions/runs/1574287379
- `docker run --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.16.11 GOFLAGS="-buildmode=pie -trimpath" go build -v`
```
eb8a4b9250c92a5fa7716ad90b97af32b900025ee1af1219cf27fd5ec3b1d1d2  local-log4j-vuln-scanner-docker
eb8a4b9250c92a5fa7716ad90b97af32b900025ee1af1219cf27fd5ec3b1d1d2  local-log4j-vuln-scanner-gitlab
```

Reference: https://wiki.archlinux.org/title/Go_package_guidelines#Flags_and_build_options