### PR TITLE
README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `--ignore-v1` flag will _exclude_ checks for log4j 1.x vulnerabilities.
 
 The `--log` flag allows everythig to be written to a log file instead of stdout/stderr.
 
-Use the `--exclude` flag to exclude subdirectories from being scanned.
+Use the `--exclude` flag to exclude subdirectories from being scanned. Can be used multiple times.
 
 If class files indicating one of the vulnerabilities are found,
 messages like the following are printed to standard output:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Linux distributions may not be recognized.
 Also included is a simple patch tool that can be used to patch out bad
 classes from JAR files by rewriting the ZIP archive structure.
 
-Binaries for x86_64 Windoes, Linux, MacOSX for tagged releases are
+Binaries for x86_64 Windows, Linux, MacOSX for tagged releases are
 provided via the
 [Releases](https://github.com/hillu/local-log4j-vuln-scanner/releases)
 page.


### PR DESCRIPTION
Two small improvements for the README.md:

1. clarify that the --exclude flag can be used multiple times
2. fixed typo: Windoes -> Windows