### PR TITLE
ignore trailing slashes for flag --exclude and improve usage info #20

### DIFF
--- a/scanner/main.go
+++ b/scanner/main.go
@@ -89,7 +89,7 @@ var quiet bool
 var ignoreV1 bool
 
 func main() {
-	flag.Var(&excludes, "exclude", "paths to exclude")
+	flag.Var(&excludes, "exclude", "paths to exclude (can be used multiple times)")
 	flag.BoolVar(&verbose, "verbose", false, "log every archive file considered")
 	flag.StringVar(&logFileName, "log", "", "log file to write output to")
 	flag.BoolVar(&quiet, "quiet", false, "no ouput unless vulnerable")

--- a/scanner/main.go
+++ b/scanner/main.go
@@ -69,7 +69,7 @@ func (flags *excludeFlags) String() string {
 }
 
 func (flags *excludeFlags) Set(value string) error {
-	*flags = append(*flags, value)
+	*flags = append(*flags, filepath.Clean(value))
 	return nil
 }
 
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	for _, root := range flag.Args() {
-		filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		filepath.Walk(filepath.Clean(root), func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				fmt.Fprintf(errFile, "%s: %s\n", path, err)
 				return nil


### PR DESCRIPTION
`--exclude /path/to/exclude/` now excludes `/path/to/exclude`

also `--help` now mentions that `--exclude` can be used multiple times. 