### PR TITLE
Added --log to scanner usage string

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ page.
 
 # Using the scanner
 
-``` console
-$ ./log4j-vuln-scanner [--verbose] [--ignore-v1] [--exclude /path/to/exclude …] /path/to/app1 /path/to/app2 …
+```
+$ ./local-log4j-vuln-scanner [--verbose] [--quiet] [--ignore-v1] \
+    [--exclude /path/to/exclude …] [--log /path/to/file.log] \
+    /path/to/app1 /path/to/app2 …
 ```
 
 The `--verbose` flag will show every .jar and .war file checked, even if no problem is found.

--- a/scanner/main.go
+++ b/scanner/main.go
@@ -115,7 +115,7 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: %s [--verbose] [--quiet] [--ignore-v1] [--exclude path] [ paths ... ]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [--verbose] [--quiet] [--ignore-v1] [--exclude <path>] [--log <file>] [ paths ... ]\n", os.Args[0])
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
* Added missing --log option in scanner usage string (+ angle brackets
  around option values).
* Also fixed usage and scanner name in README (+ wrapped text to
  accomodate narrower displays).