### PR TITLE
add 2.16 as vulnerable

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -59,6 +59,8 @@ var vulnVersions = map[string]string{
 	"ae950f9435c0ef3373d4030e7eff175ee11044e584b7f205b7a9804bbe795f9c": "log4j 2.1-2.3",       // JndiManager.class
 	"c3e95da6542945c1a096b308bf65bbd7fcb96e3d201e5a2257d85d4dedc6a078": "log4j 2.13.0-2.13.3", // JndiManager.class
 	"db07ef1ea174e000b379732681bd835cfede648a7971bf4e9a0d31981582d69e": "log4j-2.15.0",        // JndiManager.class
+	"5210e6aae7dd8a61cd16c56937c5f2ed43941487830f46e99d0d3f45bfa6f953": "log4j-2.16.0",        // JndiManager.class
+	"838ed75ea7747fa2c7068f64c76c3f623e7fe4305cdadc2ce5d7b49c7c805221": "log4j-2.16.0-debian", // JndiManager.class
 }
 
 var vulnVersionsV1 = map[string]string{

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -42,8 +42,8 @@ func TestFilterJndi(t *testing.T) {
 		v{"2.14.0", true},
 		v{"2.14.1", true},
 		v{"2.15.0", true},
-		v{"2.16.0", false},
-		v{"2.16.0-debian", false},
+		v{"2.16.0", true},
+		v{"2.16.0-debian", true},
 		v{"2.17.0", false},
 	} {
 		file := "../testdata/JndiManager.class-" + cand.version


### PR DESCRIPTION
include 2.16 as vulnerable because of [issue #43](https://github.com/hillu/local-log4j-vuln-scanner/issues/43)